### PR TITLE
Clarification of 1st round criterion

### DIFF
--- a/fill_db_with_fakes.py
+++ b/fill_db_with_fakes.py
@@ -27,7 +27,7 @@ def main():
                 "is complete, clearly written, and articulate",
                 "has a thorough and achievable outline",
                 "has a coherent and primarily technical subject",
-                "is about the Python ecosystem",
+                "is material relevant to Python and Pythonistas",
                 "has a sufficient audience among attendees"]
     for s in standards:
         l.add_standard(s)


### PR DESCRIPTION
In http://www.njl.us/essays/pycon-process/ "is about the Python ecosystem" criterion is explained to mean "material is relevant to Python and Pythonistas".  This commit ports that clearer expression of intent, and the more encompassing scope that it implies.
